### PR TITLE
Update CoC with Scoping Language, Clarification on Investigation Committee Procedure

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -69,8 +69,9 @@ beliefs which may conflict with the community ideals.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
-All complaints will be reviewed and investigated promptly and fairly.
+chisel.language@gmail.com. All complaints will be reviewed and investigated
+promptly, fairly, and publicly by a sub-committee appointed by the Technical
+Advisory Committee.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -57,6 +57,14 @@ Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
+This Code of Conduct applies for direct communication between community members.
+
+This Code of Conduct does not apply in spaces unaffiliated with the community or
+when a user is not officially representing the community. Examples of
+unaffiliated spaces or communication not representing the community include
+personal blogs and micro-blogs, political contributions, and religious/political
+beliefs which may conflict with the community ideals.
+
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be

--- a/constitution.md
+++ b/constitution.md
@@ -178,4 +178,4 @@ another member of the TAC must approve the pull request for it to be merged.
 
 ## Code of Conduct (Contributors)
 
-All Contributors are expected to abide by the code of conduct detailed in `code_of_conduct.md`, which is a verbatim copy of [Contributor Covenant 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.md).
+All Contributors are expected to abide by the code of conduct detailed in `code_of_conduct.md`, which is a modified copy of [Contributor Covenant 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/code_of_conduct.md).


### PR DESCRIPTION
This adds language to the Code of Conduct (CoC) to address feedback from @edwardcwang doing two major things:

1. The scope section is updated to add language explicitly clarifying that activities outside of the community are out-of-scope of the CoC. Previously, this was only implicitly stated.
2. The investigation process of CoC violation reporting and investigation is made explicit.