### PR TITLE
Add List of Projects

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,12 @@
+# Chisel Working Group (CWG) Projects
+
+## Current Projects:
+- FIRRTL (https://github.com/freechipsproject/firrtl)
+- Chisel 3 (https://github.com/freechipsproject/chisel3)
+- Chisel Testers (https://github.com/freechipsproject/chisel-testers)
+- Treadle (https://github.com/freechipsproject/treadle)
+- Bootcamp (https://github.com/freechipsproject/chisel-bootcamp)
+- Template (https://github.com/freechipsproject/chisel-template)
+- DSP Tools (https://github.com/ucb-bar/dsptools)
+- Diagrammer (https://github.com/freechipsproject/diagrammer)
+- ChiselTest (https://github.com/ucb-bar/chisel-testers2)


### PR DESCRIPTION
This is the proposed initial list of projects in the Chisel Working Group. Each project has been approved for relicensing to Apache 2.0 (FIRRTL and Treadle already have been). They will later be moved to the CHIPS Alliance Github project: https://github.com/chipsalliance/.